### PR TITLE
Refactor/Fix Warnings When Building REPL

### DIFF
--- a/repl/Makefile
+++ b/repl/Makefile
@@ -6,7 +6,7 @@ include $(LISPBM)/lispbm.mk
 PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include
 PLATFORM_SRC     = $(LISPBM)/platform/linux/src/platform_mutex.c
 
-CCFLAGS =  -g -O2 -Wall -Wconversion -Wsign-compare -pedantic -std=c11 -DFULL_RTS_LIB
+CCFLAGS =  -g -O2 -Wall -Wconversion -Wsign-compare -pedantic -std=c11 -DFULL_RTS_LIB -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 
 PICCFLAGS = -O2 -Wall -Wconversion -pedantic -std=c11
 

--- a/repl/buffer.c
+++ b/repl/buffer.c
@@ -22,49 +22,49 @@
 #include <stdbool.h>
 
 void buffer_append_int16(uint8_t* buffer, int16_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 void buffer_append_uint16(uint8_t* buffer, uint16_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 void buffer_append_int32(uint8_t* buffer, int32_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 24;
-	buffer[(*index)++] = number >> 16;
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 24);
+	buffer[(*index)++] = (uint8_t)(number >> 16);
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 void buffer_append_uint32(uint8_t* buffer, uint32_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 24;
-	buffer[(*index)++] = number >> 16;
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 24);
+	buffer[(*index)++] = (uint8_t)(number >> 16);
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 void buffer_append_int64(uint8_t* buffer, int64_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 56;
-	buffer[(*index)++] = number >> 48;
-	buffer[(*index)++] = number >> 40;
-	buffer[(*index)++] = number >> 32;
-	buffer[(*index)++] = number >> 24;
-	buffer[(*index)++] = number >> 16;
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 56);
+	buffer[(*index)++] = (uint8_t)(number >> 48);
+	buffer[(*index)++] = (uint8_t)(number >> 40);
+	buffer[(*index)++] = (uint8_t)(number >> 32);
+	buffer[(*index)++] = (uint8_t)(number >> 24);
+	buffer[(*index)++] = (uint8_t)(number >> 16);
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 void buffer_append_uint64(uint8_t* buffer, uint64_t number, int32_t *index) {
-	buffer[(*index)++] = number >> 56;
-	buffer[(*index)++] = number >> 48;
-	buffer[(*index)++] = number >> 40;
-	buffer[(*index)++] = number >> 32;
-	buffer[(*index)++] = number >> 24;
-	buffer[(*index)++] = number >> 16;
-	buffer[(*index)++] = number >> 8;
-	buffer[(*index)++] = number;
+	buffer[(*index)++] = (uint8_t)(number >> 56);
+	buffer[(*index)++] = (uint8_t)(number >> 48);
+	buffer[(*index)++] = (uint8_t)(number >> 40);
+	buffer[(*index)++] = (uint8_t)(number >> 32);
+	buffer[(*index)++] = (uint8_t)(number >> 24);
+	buffer[(*index)++] = (uint8_t)(number >> 16);
+	buffer[(*index)++] = (uint8_t)(number >> 8);
+	buffer[(*index)++] = (uint8_t)(number);
 }
 
 
@@ -146,7 +146,7 @@ void buffer_append_float32_auto(uint8_t* buffer, float number, int32_t *index) {
 }
 
 void buffer_append_float64_auto(uint8_t* buffer, double number, int32_t *index) {
-	float n = number;
+	float n = (float)number;
 	float err = (float)(number - (double)n);
 	buffer_append_float32_auto(buffer, n, index);
 	buffer_append_float32_auto(buffer, err, index);
@@ -231,7 +231,7 @@ float buffer_get_float32_auto(const uint8_t *buffer, int32_t *index) {
 
 	float sig = 0.0;
 	if (e != 0 || sig_i != 0) {
-		sig = (float)sig_i / (8388608.0 * 2.0) + 0.5;
+		sig = (float)sig_i / (8388608.0f * 2.0f) + 0.5f;
 		e -= 126;
 	}
 

--- a/repl/packet.c
+++ b/repl/packet.c
@@ -43,18 +43,18 @@ void packet_send_packet(unsigned char *data, unsigned int len, PACKET_STATE_t *s
 		return;
 	}
 
-	int b_ind = 0;
+	unsigned int b_ind = 0;
 
 	if (len <= 255) {
 		state->tx_buffer[b_ind++] = 2;
-		state->tx_buffer[b_ind++] = len;
+		state->tx_buffer[b_ind++] = (unsigned char)len;
 	} else if (len <= 65535) {
 		state->tx_buffer[b_ind++] = 3;
-		state->tx_buffer[b_ind++] = len >> 8;
+		state->tx_buffer[b_ind++] = (unsigned char)(len >> 8);
 		state->tx_buffer[b_ind++] = len & 0xFF;
 	} else {
 		state->tx_buffer[b_ind++] = 4;
-		state->tx_buffer[b_ind++] = len >> 16;
+		state->tx_buffer[b_ind++] = (unsigned char)(len >> 16);
 		state->tx_buffer[b_ind++] = (len >> 8) & 0xFF;
 		state->tx_buffer[b_ind++] = len & 0xFF;
 	}
@@ -115,8 +115,8 @@ void packet_process_byte(uint8_t rx_data, PACKET_STATE_t *state) {
 		}
 
 		if (res > 0) {
-			data_len -= res;
-			state->rx_read_ptr += res;
+			data_len -= (unsigned int)res;
+			state->rx_read_ptr += (unsigned int)res;
 		} else if (res == -1) {
 			// Something went wrong. Move pointer forward and try again.
 			state->rx_read_ptr++;
@@ -183,7 +183,7 @@ static int try_decode_packet(unsigned char *buffer, unsigned int in_len,
 
 	// Not enough data to determine length
 	if (in_len < data_start) {
-		*bytes_left = data_start - in_len;
+		*bytes_left = (int)(data_start - in_len);
 		return -2;
 	}
 
@@ -221,7 +221,7 @@ static int try_decode_packet(unsigned char *buffer, unsigned int in_len,
 
 	// Need more data to determine rest of packet
 	if (in_len < (len + data_start + 3)) {
-		*bytes_left = (len + data_start + 3) - in_len;
+		*bytes_left = (int)((len + data_start + 3) - in_len);
 		return -2;
 	}
 
@@ -239,7 +239,7 @@ static int try_decode_packet(unsigned char *buffer, unsigned int in_len,
 			process_func(buffer + data_start, len);
 		}
 
-		return len + data_start + 3;
+		return (int)(len + data_start + 3);
 	} else {
 		return -1;
 	}

--- a/repl/repl.c
+++ b/repl/repl.c
@@ -106,14 +106,14 @@ volatile bool silent_mode = false;
 
 struct read_state_s {
   char *str;   // String being read.
-  int  cid;    // Reader thread id.
+  lbm_cid cid;    // Reader thread id.
   struct read_state_s *next;
 };
 
 typedef struct read_state_s read_state_t;
 read_state_t *readers = NULL; // ongoing list of readers.
 
-void add_reader(char *str, int cid) {
+void add_reader(char *str, lbm_cid cid) {
   read_state_t *new_reader = (read_state_t*)malloc(sizeof(read_state_t));
   new_reader->str = str;
   new_reader->cid = cid;
@@ -133,7 +133,7 @@ void clear_readers(void) {
   readers = NULL;
 }
 
-bool drop_reader(int cid) {
+bool drop_reader(lbm_cid cid) {
 
   bool r = false;
   read_state_t *prev = NULL;
@@ -1225,7 +1225,7 @@ long unsigned int get_cpu_last_ticks = 1;
 
 float get_cpu_usage(void) {
 
-  int ticks_per_s = sysconf(_SC_CLK_TCK);
+  int ticks_per_s = (int)sysconf(_SC_CLK_TCK);
   float cpu_usage = -1;
 
   char fname[200] ;
@@ -1242,7 +1242,7 @@ float get_cpu_usage(void) {
       unsigned int t_diff = t_now - get_cpu_last_time;
 
       // Not sure about this :)
-      cpu_usage = 100.0f * (float)(((float)ticks / ((float)t_diff / 1000000.0f))  / ticks_per_s);
+      cpu_usage = 100.0f * (float)(((float)ticks / ((float)t_diff / 1000000.0f))  / (float)ticks_per_s);
       if (cpu_usage > 100) cpu_usage = 100;
       if (cpu_usage < 0) cpu_usage = 0;
 
@@ -1586,7 +1586,7 @@ void repl_process_cmd(unsigned char *data, unsigned int len,
           if (buffer) {
             memcpy(buffer, data, len);
             lbm_create_string_char_channel(&string_tok_state, &string_tok, buffer);
-            int cid = lbm_load_and_eval_expression(&string_tok);
+            lbm_cid cid = lbm_load_and_eval_expression(&string_tok);
             if (cid >= 0) { 
               add_reader(buffer, cid);
             } else {
@@ -1820,7 +1820,7 @@ void send_tcp_bytes(unsigned char *buffer, unsigned int len) {
   int error_cnt = 0;
 
   while (to_write > 0) {
-    int written = write (connected_socket, buffer + ((int)len - to_write), (size_t)to_write);
+    ssize_t written = write(connected_socket, buffer + ((int)len - to_write), (size_t)to_write);
     if (written < 0) {
       error_cnt ++;
       if (error_cnt > SEND_MAX_RETRY) {
@@ -1828,7 +1828,7 @@ void send_tcp_bytes(unsigned char *buffer, unsigned int len) {
       }
       sleep_callback(10);
     }
-    to_write -= written;
+    to_write -= (int)written;
   }
 }
 
@@ -1847,7 +1847,7 @@ void *vesctcp_client_handler(void *arg) {
   uint8_t buffer[1024];
   packet_init(send_tcp_bytes, process_packet_local,&packet);
   send_func = send_packet_local;
-  int len;
+  ssize_t len;
 
   struct sockaddr_in addr;
   socklen_t addr_size = sizeof(struct sockaddr_in);
@@ -1919,6 +1919,7 @@ int main(int argc, char **argv) {
 
       if (client_socket >= 0 && !vesctcp_server_in_use ) {
         vesctcp_server_in_use = true;
+        // TODO: is this cast really ok?
         pthread_create(&client_thread, NULL, vesctcp_client_handler, (void*)client_socket);
 
       } else if (client_socket >= 0) {

--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -1928,33 +1928,33 @@ static void eval_var(eval_context_t *ctx) {
   if (ctx->K.sp >= 4) { // Possibly in progn
     lbm_value sv = ctx->K.data[ctx->K.sp - 1];
     if (IS_CONTINUATION(sv) && (sv == PROGN_REST)) {
-    lbm_uint sp = ctx->K.sp;
-    uint32_t is_copied = lbm_dec_as_u32(ctx->K.data[sp-3]);
-    if (is_copied == 0) {
-      lbm_value env;
-      WITH_GC(env, lbm_env_copy_spine(ctx->K.data[sp-4]));
-      ctx->K.data[sp-3] = lbm_enc_u(1);
-      ctx->K.data[sp-4] = env;
-    }
-    lbm_value new_env = ctx->K.data[sp-4];
-    lbm_value args = get_cdr(ctx->curr_exp);
-    lbm_value key = get_car(args);
-    create_binding_location(key, &new_env);
-    ctx->K.data[sp-4] = new_env;
+      lbm_uint sp = ctx->K.sp;
+      uint32_t is_copied = lbm_dec_as_u32(ctx->K.data[sp-3]);
+      if (is_copied == 0) {
+        lbm_value env;
+        WITH_GC(env, lbm_env_copy_spine(ctx->K.data[sp-4]));
+        ctx->K.data[sp-3] = lbm_enc_u(1);
+        ctx->K.data[sp-4] = env;
+      }
+      lbm_value new_env = ctx->K.data[sp-4];
+      lbm_value args = get_cdr(ctx->curr_exp);
+      lbm_value key = get_car(args);
+      create_binding_location(key, &new_env);
+      ctx->K.data[sp-4] = new_env;
 
-    lbm_value v_exp = get_cadr(args);
-    lbm_value *sptr = stack_reserve(ctx, 3);
-    sptr[0] = new_env;
-    sptr[1] = key;
-    sptr[2] = PROGN_VAR;
-    // Activating the new environment before the evaluation of the value to be bound,
-    // means that other variables with same name will be shadowed already in the value
-    // body.
-    // The way closures work, the var-variable needs to be in scope during val evaluation
-    // for a recursive closure to be possible.
-    ctx->curr_env = new_env;
-    ctx->curr_exp = v_exp;
-    return;
+      lbm_value v_exp = get_cadr(args);
+      lbm_value *sptr = stack_reserve(ctx, 3);
+      sptr[0] = new_env;
+      sptr[1] = key;
+      sptr[2] = PROGN_VAR;
+      // Activating the new environment before the evaluation of the value to be bound,
+      // means that other variables with same name will be shadowed already in the value
+      // body.
+      // The way closures work, the var-variable needs to be in scope during val evaluation
+      // for a recursive closure to be possible.
+      ctx->curr_env = new_env;
+      ctx->curr_exp = v_exp;
+      return;
     }
   }
   lbm_set_error_reason((char*)lbm_error_str_var_outside_progn);


### PR DESCRIPTION
Fixed all warnings generated by explicitly casting types and switching some usages of int to the appropriate `lbm_*` type.

Also fixed the indentation of `eval_var` in "eval.cps.c".