### PR TITLE
Fix index of font argument type check

### DIFF
--- a/src/extensions/display_extensions.c
+++ b/src/extensions/display_extensions.c
@@ -2584,7 +2584,7 @@ static lbm_value ext_text(lbm_value *args, lbm_uint argn) {
   img_buf.data = image_buffer_data((uint8_t*)arr->data);
 
   lbm_array_header_t *font = 0;
-  if (lbm_type_of(args[5]) == LBM_TYPE_ARRAY) {
+  if (lbm_type_of(args[argn - 2]) == LBM_TYPE_ARRAY) {
     font = (lbm_array_header_t *)lbm_car(args[argn - 2]);
   }
 


### PR DESCRIPTION
This worked by accident for antialiased text
because the next argument is a string that is
normally LBM_ARRAY. However, some strings
are LBM_ARRAY_CONST, and for that case this would
break.