### PR TITLE
feat: Make `apply` not evaluate arguments 2: Electric Boogaloo

### DIFF
--- a/doc/dynref.lisp
+++ b/doc/dynref.lisp
@@ -14,21 +14,7 @@
               )
              )
   )
-              
-             
 
-(define df-apply
-  (ref-entry "apply"
-             (list
-              (para (list "Apply a function taking n arguments to a list of n elements"
-                          ))
-              (code '((apply + (list 1 2 3))
-                      ))
-              end
-              )
-             )
-  )
-  
 (define df-filter
   (ref-entry "filter"
              (list
@@ -183,7 +169,6 @@
   (section 2 "functions"
            (list 'hline
                  df-abs
-                 df-apply
                  df-filter
                  df-foldl
                  df-foldr

--- a/doc/dynref.md
+++ b/doc/dynref.md
@@ -126,40 +126,6 @@ Compute the absolute value
 ---
 
 
-### apply
-
-Apply a function taking n arguments to a list of n elements 
-
-<table>
-<tr>
-<td> Example </td> <td> Result </td>
-</tr>
-<tr>
-<td>
-
-```clj
-(apply + (list 1 2 3))
-```
-
-
-</td>
-<td>
-
-```clj
-6
-```
-
-
-</td>
-</tr>
-</table>
-
-
-
-
----
-
-
 ### filter
 
 Filter a list from unwanted elements as decided by a predicate 

--- a/include/eval_cps.h
+++ b/include/eval_cps.h
@@ -1,5 +1,6 @@
 /*
     Copyright 2018, 2020 - 2025 Joel Svensson  svenssonjoel@yahoo.se
+              2025 Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -69,7 +70,7 @@ typedef struct eval_context_s{
   uint32_t  num_mail;    /* Number of messages in mailbox */
   uint32_t  flags;
   lbm_value r;
-  char *error_reason;
+  const char *error_reason;
   bool  app_cont;
   lbm_stack_t K;
   lbm_uint timestamp;
@@ -258,7 +259,7 @@ uint32_t lbm_get_eval_state(void);
  *  that errored is removed.
  * \param error_str
  */
-void lbm_set_error_reason(char *error_str);
+void lbm_set_error_reason(const char *error_str);
 /** Provide the expression that is most suspicious
  *  in relation to the error at hand.
  * \param lbm_value

--- a/include/lbm_constants.h
+++ b/include/lbm_constants.h
@@ -1,5 +1,6 @@
 /*
     Copyright 2022 Joel Svensson  svenssonjoel@yahoo.se
+              2025 Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,4 +30,6 @@ extern const char* lbm_error_str_forbidden_in_atomic;
 extern const char* lbm_error_str_no_number;
 extern const char* lbm_error_str_not_a_boolean;
 extern const char* lbm_error_str_incorrect_arg;
+extern const char* lbm_error_str_not_applicable;
+
 #endif

--- a/include/lbm_defines.h
+++ b/include/lbm_defines.h
@@ -1,5 +1,6 @@
 /*
     Copyright 2022, 2024, 2025 Joel Svensson        svenssonjoel@yahoo.se
+              2025 Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -372,7 +373,7 @@
 #define SYM_SORT                  0x30014
 #define SYM_REST_ARGS             0x30015
 #define SYM_ROTATE                0x30016
-#define SYM_POPRET                0x30017
+#define SYM_APPLY                 0x30017
 
 #define SYMBOL_KIND(X)          ((X) >> 16)
 #define SYMBOL_KIND_SPECIAL     0
@@ -521,6 +522,7 @@
 #define ENC_SYM_TRAP                  ENC_SYM(SYM_TRAP)
 #define ENC_SYM_CALL_CC_UNSAFE        ENC_SYM(SYM_CALL_CC_UNSAFE)
 #define ENC_SYM_CONT_SP               ENC_SYM(SYM_CONT_SP)
+#define ENC_SYM_APPLY                 ENC_SYM(SYM_APPLY)
 
 #define ENC_SYM_ADD           ENC_SYM(SYM_ADD)
 #define ENC_SYM_SUB           ENC_SYM(SYM_SUB)

--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -2419,7 +2419,7 @@ static void cont_wait(eval_context_t *ctx) {
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
+static inline __attribute__ ((always_inline)) lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
   /* Continuation created using call-cc.
    * ((SYM_CONT . cont-array) arg0 )
    */
@@ -2466,7 +2466,7 @@ static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
+static inline __attribute__ ((always_inline)) lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
   // continuation created using call-cc-unsafe
   // ((SYM_CONT_SP . stack_ptr) arg0 )
   lbm_value c = get_cadr(ctx->r); /* should be the stack_ptr*/
@@ -2511,7 +2511,7 @@ static lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
  * @param curr_env The environment to re-evaluate the result of the macro
  *   experssion in. 
  */
-static void setup_macro(eval_context_t *ctx, lbm_value args, lbm_value curr_env) {
+static inline __attribute__ ((always_inline)) void setup_macro(eval_context_t *ctx, lbm_value args, lbm_value curr_env) {
   /*
    * Perform macro expansion.
    * Macro expansion is really just evaluation in an

--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -1,5 +1,6 @@
 /*
     Copyright 2018, 2020 - 2025 Joel Svensson    svenssonjoel@yahoo.se
+              2025 Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -150,6 +151,7 @@ const char* lbm_error_str_flash_full = "Flash memory is full.";
 const char* lbm_error_str_variable_not_bound = "Variable not bound.";
 const char* lbm_error_str_read_no_mem = "Out of memory while reading.";
 const char* lbm_error_str_qq_expand = "Quasiquotation expansion error.";
+const char* lbm_error_str_not_applicable = "Value is not applicable.";
 
 static lbm_value lbm_error_suspect;
 static bool lbm_error_has_suspect = false;
@@ -1050,6 +1052,9 @@ static void finish_ctx(void) {
   ctx_done_callback(ctx_running);
 
   lbm_free(ctx_running->name); //free name if in LBM_MEM
+  // It's technically a bit iffy to cast away the const attribute, but we only
+  // treat the string as non-const if it came from LBM_MEM (by eventually
+  // freeing it), in which case it's definitely not actually const.
   lbm_memory_free((lbm_uint*)ctx_running->error_reason); //free error_reason if in LBM_MEM
 
   lbm_memory_free((lbm_uint*)ctx_running->mailbox);
@@ -1068,7 +1073,7 @@ void lbm_set_error_suspect(lbm_value suspect) {
   lbm_error_has_suspect = true;
 }
 
-void lbm_set_error_reason(char *error_str) {
+void lbm_set_error_reason(const char *error_str) {
   if (ctx_running != NULL) {
     ctx_running->error_reason = error_str;
   }
@@ -2400,6 +2405,154 @@ static void cont_wait(eval_context_t *ctx) {
   }
 }
 
+/***************************************************/
+/* Application helper functions.                   */
+
+
+/**
+ * @brief Setup application of cont object (created by call-cc)
+ * 
+ * The "function" form, e.g. `(SYM_CONT . cont-array)`, is expected to be stored
+ * in `ctx->r`.
+ * 
+ * @param args List of the arguments to apply with.
+ * @return lbm_value The resulting argument value which should either be
+ *   evaluated or passed on directly depending on how you use this.
+ */
+static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
+  /* Continuation created using call-cc.
+   * ((SYM_CONT . cont-array) arg0 )
+   */
+  lbm_value c = get_cdr(ctx->r); /* should be the continuation array*/
+
+  if (!lbm_is_lisp_array_r(c)) {
+    ERROR_CTX(ENC_SYM_FATAL_ERROR);
+  }
+  
+  lbm_value arg;
+  lbm_uint arg_count = lbm_list_length(args);
+  switch (arg_count) {
+  case 0:
+    arg = ENC_SYM_NIL;
+    break;
+  case 1:
+    arg = get_car(args);
+    break;
+  default:
+    lbm_set_error_reason(lbm_error_str_num_args);
+    ERROR_CTX(ENC_SYM_EERROR);
+  }
+
+  lbm_stack_clear(&ctx->K);
+
+  lbm_array_header_t *arr = assume_array(c);
+  ctx->K.sp = arr->size / sizeof(lbm_uint);
+  memcpy(ctx->K.data, arr->data, arr->size);
+
+  lbm_value atomic;
+  lbm_pop(&ctx->K, &atomic);
+  is_atomic = atomic ? 1 : 0;
+  
+  return arg;
+}
+
+/**
+ * @brief Setup application of cont sp object (created by call-cc-unsafe)
+ * 
+ * The "function" form, e.g. `(SYM_CONT_SP . stack_ptr)` is expected to be
+ * stored in `ctx->r`.
+ * 
+ * @param args List of the arguments to apply with.
+ * @return lbm_value The resulting argument value which should either be
+ *   evaluated or passed on directly depending on how you use this.
+ */
+static lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
+  // continuation created using call-cc-unsafe
+  // ((SYM_CONT_SP . stack_ptr) arg0 )
+  lbm_value c = get_cadr(ctx->r); /* should be the stack_ptr*/
+  lbm_value atomic = get_cadr(get_cdr(ctx->r));
+
+  if (!lbm_is_number(c)) {
+    ERROR_CTX(ENC_SYM_FATAL_ERROR);
+  }
+
+  lbm_uint sp = (lbm_uint)lbm_dec_i(c);
+
+  lbm_value arg;
+  lbm_uint arg_count = lbm_list_length(args);
+  switch (arg_count) {
+  case 0:
+    arg = ENC_SYM_NIL;
+    break;
+  case 1:
+    arg = get_car(args);
+    break;
+  default:
+    lbm_set_error_reason(lbm_error_str_num_args);
+    ERROR_CTX(ENC_SYM_EERROR);
+  }
+  
+  if (sp > 0 && sp <= ctx->K.sp && IS_CONTINUATION(ctx->K.data[sp-1])) {
+    is_atomic = atomic ? 1 : 0; // works fine with nil/true
+    ctx->K.sp = sp;
+    return arg;
+  } else {
+    ERROR_CTX(ENC_SYM_FATAL_ERROR);
+  }
+}
+
+/**
+ * @brief Setup application of macro
+ * 
+ * The macro form, e.g. `(macro (...) ...)`, is expected to be stored in
+ * `ctx->r`.
+ * 
+ * @param args List of the arguments to apply the macro with.
+ * @param curr_env The environment to re-evaluate the result of the macro
+ *   experssion in. 
+ */
+static void setup_macro(eval_context_t *ctx, lbm_value args, lbm_value curr_env) {
+  /*
+   * Perform macro expansion.
+   * Macro expansion is really just evaluation in an
+   * environment augmented with the unevaluated expressions passed
+   * as arguments.
+   */
+
+  lbm_uint *sptr = stack_reserve(ctx, 2);
+  // For EVAL_R, placed here already to protect from GC
+  sptr[0] = curr_env;
+
+  lbm_value curr_param = get_cadr(ctx->r);
+  lbm_value curr_arg = args;
+  lbm_value expand_env = curr_env;
+  while (lbm_is_cons(curr_param) &&
+          lbm_is_cons(curr_arg)) {
+    lbm_cons_t *param_cell = lbm_ref_cell(curr_param); // already checked that cons.
+    lbm_cons_t *arg_cell = lbm_ref_cell(curr_arg);
+    lbm_value car_curr_param = param_cell->car;
+    lbm_value cdr_curr_param = param_cell->cdr;
+    lbm_value car_curr_arg = arg_cell->car;
+    lbm_value cdr_curr_arg = arg_cell->cdr;
+
+    lbm_value entry = cons_with_gc(car_curr_param, car_curr_arg, expand_env);
+    lbm_value aug_env = cons_with_gc(entry, expand_env,ENC_SYM_NIL);
+    expand_env = aug_env;
+
+    curr_param = cdr_curr_param;
+    curr_arg   = cdr_curr_arg;
+  }
+  /* Two rounds of evaluation is performed.
+   * First to instantiate the arguments into the macro body.
+   * Second to evaluate the resulting program.
+   */
+  
+  sptr[1] = EVAL_R;
+  lbm_value exp = get_cadr(get_cdr(ctx->r));
+  ctx->curr_exp = exp;
+  ctx->curr_env = expand_env;
+}
+
 static lbm_value perform_setvar(lbm_value key, lbm_value val, lbm_value env) {
 
   lbm_uint s = lbm_dec_sym(key);
@@ -3130,6 +3283,8 @@ static void apply_rotate(lbm_value *args, lbm_uint nargs, eval_context_t *ctx) {
   ERROR_CTX(ENC_SYM_EERROR);
 }
 
+static void apply_apply(lbm_value *args, lbm_uint nargs, eval_context_t *ctx);
+
 /***************************************************/
 /* Application lookup table                        */
 
@@ -3159,6 +3314,7 @@ static const apply_fun fun_table[] =
    apply_sort,
    apply_rest_args,
    apply_rotate,
+   apply_apply,
   };
 
 /***************************************************/
@@ -4625,117 +4781,24 @@ static void cont_application_start(eval_context_t *ctx) {
         ERROR_AT_CTX(ENC_SYM_EERROR, ctx->r);
       }
     } break;
-    case ENC_SYM_CONT:{
-      /* Continuation created using call-cc.
-       * ((SYM_CONT . cont-array) arg0 )
-       */
-      lbm_value c = get_cdr(ctx->r); /* should be the continuation array*/
-
-      if (!lbm_is_lisp_array_r(c)) {
-        ERROR_CTX(ENC_SYM_FATAL_ERROR);
-      }
-
-      lbm_uint arg_count = lbm_list_length(args);
-      lbm_value arg;
-      switch (arg_count) {
-      case 0:
-        arg = ENC_SYM_NIL;
-        break;
-      case 1:
-        arg = get_car(args);
-        break;
-      default:
-        lbm_set_error_reason((char*)lbm_error_str_num_args);
-        ERROR_CTX(ENC_SYM_EERROR);
-      }
-      lbm_stack_clear(&ctx->K);
-
-      lbm_array_header_t *arr = assume_array(c);
-      ctx->K.sp = arr->size / sizeof(lbm_uint);
-      memcpy(ctx->K.data, arr->data, arr->size);
-
-      lbm_value atomic;
-      lbm_pop(&ctx->K, &atomic);
-      is_atomic = atomic ? 1 : 0;
-
-      ctx->curr_exp = arg;
+    case ENC_SYM_CONT:{  
+      ctx->curr_exp = setup_cont(ctx, args);
     } break;
     case ENC_SYM_CONT_SP: {
-      // continuation created using call-cc-unsafe
-      // ((SYM_CONT_SP . stack_ptr) arg0 )
-      lbm_value c = get_cadr(ctx->r); /* should be the stack_ptr*/
-      lbm_value atomic = get_cadr(get_cdr(ctx->r));
-
-      if (!lbm_is_number(c)) {
-        ERROR_CTX(ENC_SYM_FATAL_ERROR);
-      }
-
-      lbm_uint sp = (lbm_uint)lbm_dec_i(c);
-
-      lbm_uint arg_count = lbm_list_length(args);
-      lbm_value arg;
-      switch (arg_count) {
-      case 0:
-        arg = ENC_SYM_NIL;
-        break;
-      case 1:
-        arg = get_car(args);
-        break;
-      default:
-        lbm_set_error_reason((char*)lbm_error_str_num_args);
-        ERROR_CTX(ENC_SYM_EERROR);
-      }
-      if (sp > 0 && sp <= ctx->K.sp && IS_CONTINUATION(ctx->K.data[sp-1])) {
-              is_atomic = atomic ? 1 : 0; // works fine with nil/true
-              ctx->K.sp = sp;
-              ctx->curr_exp = arg;
-              return;
-      } else {
-        ERROR_CTX(ENC_SYM_FATAL_ERROR);
-      }
+      ctx->curr_exp = setup_cont_sp(ctx, args);
+      return;
     } break;
     case ENC_SYM_MACRO:{
-      /*
-       * Perform macro expansion.
-       * Macro expansion is really just evaluation in an
-       * environment augmented with the unevaluated expressions passed
-       * as arguments.
-       */
       lbm_value env = (lbm_value)sptr[0];
-
-      lbm_value curr_param = get_cadr(ctx->r);
-      lbm_value curr_arg = args;
-      lbm_value expand_env = env;
-      while (lbm_is_cons(curr_param) &&
-             lbm_is_cons(curr_arg)) {
-        lbm_cons_t *param_cell = lbm_ref_cell(curr_param); // already checked that cons.
-        lbm_cons_t *arg_cell = lbm_ref_cell(curr_arg);
-        lbm_value car_curr_param = param_cell->car;
-        lbm_value cdr_curr_param = param_cell->cdr;
-        lbm_value car_curr_arg = arg_cell->car;
-        lbm_value cdr_curr_arg = arg_cell->cdr;
-
-        lbm_value entry = cons_with_gc(car_curr_param, car_curr_arg, expand_env);
-        lbm_value aug_env = cons_with_gc(entry, expand_env,ENC_SYM_NIL);
-        expand_env = aug_env;
-
-        curr_param = cdr_curr_param;
-        curr_arg   = cdr_curr_arg;
-      }
-      /* Two rounds of evaluation is performed.
-       * First to instantiate the arguments into the macro body.
-       * Second to evaluate the resulting program.
-       */
-      sptr[1] = EVAL_R;
-      lbm_value exp = get_cadr(get_cdr(ctx->r));
-      ctx->curr_exp = exp;
-      ctx->curr_env = expand_env;
+      pop_stack_ptr(ctx, 2);
+      setup_macro(ctx, args, env);
     } break;
     default:
       ERROR_CTX(ENC_SYM_EERROR);
     }
   } else {
-    ERROR_CTX(ENC_SYM_EERROR);
+    lbm_set_error_reason(lbm_error_str_not_applicable);
+    ERROR_AT_CTX(ENC_SYM_EERROR, ctx->r);
   }
 }
 
@@ -5350,7 +5413,7 @@ static const cont_fun continuations[NUM_CONTINUATIONS] =
     cont_wrap_result,
     cont_recv_to_retry,
     cont_read_start_array,
-    cont_read_append_array
+    cont_read_append_array,
   };
 
 /*********************************************************/
@@ -5439,6 +5502,122 @@ static void evaluation_step(void){
   return;
 }
 
+// Placed down here since it depends on a lot of things.
+// (apply fun arg-list)
+static void apply_apply(lbm_value *args, lbm_uint nargs, eval_context_t *ctx) {
+  if (nargs != 2 || !lbm_is_list(args[1])) {
+    ERROR_CTX(ENC_SYM_EERROR);
+  }
+  
+  lbm_value fun = args[0];
+  lbm_value arg_list = args[1];
+
+  lbm_stack_drop(&ctx->K, nargs+1);
+  
+  if (lbm_is_symbol(fun) && ((fun & ENC_SPECIAL_FORMS_MASK) == ENC_SPECIAL_FORMS_BIT)) {
+    // Since the special form evaluators are responsible for conditionally
+    // evaluating their arguments there is no easy way to prevent them
+    // evaluating their arguments. Therefore we compromise and allow them to do
+    // so, even if this isn't always how you would expect apply to work.
+    // For instance, `(apply and '(a))` would try evaluating the symbol `a`,
+    // instead of just returning the symbol `a` outright.
+    
+    // Evaluator functions expect the current expression to equal the special
+    // form, i.e. including the function symbol.
+    lbm_value fun_and_args = cons_with_gc(fun, arg_list, ENC_SYM_NIL);
+    ctx->curr_exp = fun_and_args;
+    lbm_uint eval_index = lbm_dec_sym(fun) & SPECIAL_FORMS_INDEX_MASK;
+    evaluators[eval_index](ctx);
+    return;
+  } else if (lbm_is_symbol(fun)) {
+    stack_reserve(ctx, 1)[0] = fun;
+    size_t arg_count = 0;
+    for (lbm_value current = arg_list; lbm_is_cons(current); current = get_cdr(current)) {
+      stack_reserve(ctx, 1)[0] = get_car(current);
+      arg_count++;
+    }
+    lbm_value *fun_and_args = get_stack_ptr(ctx, arg_count + 1);
+    application(ctx, fun_and_args, arg_count);
+    return;
+  } else if (lbm_is_cons(fun)) {
+    switch (get_car(fun)) {
+      case ENC_SYM_CLOSURE: {
+        lbm_value closure[3];
+        extract_n(get_cdr(fun), closure, 3);
+        
+        lbm_value env = closure[CLO_ENV];
+        
+        lbm_value current_params = closure[CLO_PARAMS];
+        lbm_value current_args = arg_list;
+        
+        while (true) {
+          bool params_empty = !lbm_is_cons(current_params);
+          bool args_empty = !lbm_is_cons(current_args);
+          if (!params_empty && !args_empty) {
+            lbm_value car_params;
+            lbm_value car_args;
+            lbm_value cdr_params;
+            lbm_value cdr_args;
+            get_car_and_cdr(current_params, &car_params, &cdr_params);
+            get_car_and_cdr(current_args, &car_args, &cdr_args);
+            
+            // More parameters to bind
+            env = allocate_binding(
+              car_params,
+              car_args,
+              env
+            );
+            
+            current_params = cdr_params;
+            current_args = cdr_args;
+          } else if (params_empty && !args_empty) {
+            // More arguments but all parameters have been bound
+            env = allocate_binding(ENC_SYM_REST_ARGS, current_args, env);
+            break;
+          } else if (params_empty && args_empty) {
+            // All parameters and arguments have been bound
+            break;
+          } else {
+            // More parameters to bind but no arguments left
+            lbm_set_error_reason(lbm_error_str_num_args);
+            ERROR_CTX(ENC_SYM_EERROR);
+          }
+        }
+        
+        ctx->curr_env = env;
+        ctx->curr_exp = closure[CLO_BODY];
+        return;
+      } break;
+      case ENC_SYM_CONT:{
+        ctx->r = fun;
+        ctx->r = setup_cont(ctx, arg_list);
+        ctx->app_cont = true;
+        return;
+      } break;
+      case ENC_SYM_CONT_SP: {
+        ctx->r = fun;
+        ctx->r = setup_cont_sp(ctx, arg_list);
+        ctx->app_cont = true;
+        return;
+      } break;
+      case ENC_SYM_MACRO:{
+        ctx->r = fun;
+        setup_macro(ctx, arg_list, ctx->curr_env);
+        return;
+      } break;
+      default: {
+        lbm_set_error_reason(lbm_error_str_not_applicable);
+        ERROR_AT_CTX(ENC_SYM_EERROR, fun);
+      } break;
+    }
+  } else {
+    lbm_set_error_reason(lbm_error_str_not_applicable);
+    ERROR_AT_CTX(ENC_SYM_EERROR, fun);
+  }
+  
+  // Unreachable
+  ERROR_CTX(ENC_SYM_FATAL_ERROR);
+}
 
 // Reset has a built in pause.
 // so after reset, continue.

--- a/src/extensions/lbm_dyn_lib.c
+++ b/src/extensions/lbm_dyn_lib.c
@@ -1,6 +1,7 @@
 /*
     Copyright 2023, 2025 Joel Svensson        svenssonjoel@yahoo.se
               2022       Benjamin Vedder      benjamin@vedder.se
+              2025       Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,8 +30,6 @@ static const char* lbm_dyn_fun[] = {
 
   "(defun foldr (f init lst)"
   "(if (eq lst nil) init (f (car lst) (foldr f init (cdr lst)))))",
-
-  "(defun apply (f lst) (eval (cons f lst)))",
 
   "(defun zipwith (f xs ys) "
   "(let (( zip-acc (lambda (acc xs ys) "

--- a/src/symrepr.c
+++ b/src/symrepr.c
@@ -1,5 +1,6 @@
 /*
     Copyright 2018, 2021, 2022, 2024, 2025 Joel Svensson  svenssonjoel@yahoo.se
+              2025 Rasmus Söderhielm rasmus.soderhielm@gmail.com
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -83,6 +84,7 @@ special_sym const special_symbols[] =  {
   {"rest-args"    , SYM_REST_ARGS},
   {"rotate"       , SYM_ROTATE},
   {"call-cc-unsafe", SYM_CALL_CC_UNSAFE},
+  {"apply"        , SYM_APPLY},
 
   // pattern matching
   {"?"          , SYM_MATCH_ANY},

--- a/tests/tests/test_apply_callcc.lisp
+++ b/tests/tests/test_apply_callcc.lisp
@@ -1,6 +1,8 @@
 (check (and
     (eq (call-cc (fn (return) (apply return '(a)))) 'a)
     (eq (call-cc (fn (return) (apply return '()))) nil)
+    (eq (call-cc (fn (return) (apply return (list (cons 1 2))))) '(1 . 2))
     (eq (call-cc-unsafe (fn (return) (apply return '(a)))) 'a)
     (eq (call-cc-unsafe (fn (return) (apply return '()))) nil)
+    (eq (call-cc-unsafe (fn (return) (apply return (list (cons 1 2))))) '(1 . 2))
 ))

--- a/tests/tests/test_apply_callcc.lisp
+++ b/tests/tests/test_apply_callcc.lisp
@@ -1,0 +1,6 @@
+(check (and
+    (eq (call-cc (fn (return) (apply return '(a)))) 'a)
+    (eq (call-cc (fn (return) (apply return '()))) nil)
+    (eq (call-cc-unsafe (fn (return) (apply return '(a)))) 'a)
+    (eq (call-cc-unsafe (fn (return) (apply return '()))) nil)
+))

--- a/tests/tests/test_apply_fun.lisp
+++ b/tests/tests/test_apply_fun.lisp
@@ -1,6 +1,8 @@
 (defun fun (arg) (cons arg (rest-args)))
 (defun fun-no-args () (rest-args))
 
+(defun test (a b c) (list a b c))
+
 (check (and
     (eq (apply fun '(a)) '(a))
     (eq (apply fun '(a b)) '(a b))
@@ -9,5 +11,7 @@
     (eq (apply list '(a b)) '(a b))
     (eq (apply and '(t nil)) nil)
     (= (apply + '(1 2 3)) 6)
+    (eq (apply fun (iota 3)) '(0 1 2))
+    (eq (apply (closure (a b) (list a b)) (iota 2)) '(0 1))
 ))
 

--- a/tests/tests/test_apply_fun.lisp
+++ b/tests/tests/test_apply_fun.lisp
@@ -1,0 +1,13 @@
+(defun fun (arg) (cons arg (rest-args)))
+(defun fun-no-args () (rest-args))
+
+(check (and
+    (eq (apply fun '(a)) '(a))
+    (eq (apply fun '(a b)) '(a b))
+    (eq (apply fun-no-args '()) nil)
+    (eq (apply fun-no-args '(a b)) '(a b))
+    (eq (apply list '(a b)) '(a b))
+    (eq (apply and '(t nil)) nil)
+    (= (apply + '(1 2 3)) 6)
+))
+

--- a/tests/tests/test_apply_macro.lisp
+++ b/tests/tests/test_apply_macro.lisp
@@ -1,0 +1,13 @@
+(defmacro macro-quote (arg1 arg2) `(list ',arg1 ',arg2))
+(defmacro macro-eval (arg1 arg2) `(list ,arg1 ,arg2))
+(defmacro macro-no-args () ''symbol)
+
+(check (and
+    (eq (apply macro-quote '(a b)) '(a b))
+    {
+        (var local 'c)
+        (eq (apply macro-eval '('a local)) '(a c))
+    }
+    (eq (apply macro-no-args nil) 'symbol)
+))
+

--- a/tests/tests/test_apply_macro.lisp
+++ b/tests/tests/test_apply_macro.lisp
@@ -9,5 +9,6 @@
         (eq (apply macro-eval '('a local)) '(a c))
     }
     (eq (apply macro-no-args nil) 'symbol)
+    (eq (apply (macro (arg1 arg2) `(list ,arg1 ,arg2)) (iota 2)) '(0 1))
 ))
 

--- a/tests/tests/test_arith_stress_1.lisp
+++ b/tests/tests/test_arith_stress_1.lisp
@@ -1,10 +1,3 @@
-
-
-
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_2.lisp
+++ b/tests/tests/test_arith_stress_2.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_3.lisp
+++ b/tests/tests/test_arith_stress_3.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_4.lisp
+++ b/tests/tests/test_arith_stress_4.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_5.lisp
+++ b/tests/tests/test_arith_stress_5.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_6.lisp
+++ b/tests/tests/test_arith_stress_6.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_7.lisp
+++ b/tests/tests/test_arith_stress_7.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_arith_stress_8.lisp
+++ b/tests/tests/test_arith_stress_8.lisp
@@ -1,9 +1,6 @@
 
 (define n (if (is-always-gc) 100 100000))
 
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c args res acc)
   (if (= n 0) acc
   (progn

--- a/tests/tests/test_read_stress_2.lisp
+++ b/tests/tests/test_read_stress_2.lisp
@@ -1,8 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
-
 (defun f ()
   (apply + (rest-args)))
 

--- a/tests/tests/test_rest_args_stress_1.lisp
+++ b/tests/tests/test_rest_args_stress_1.lisp
@@ -1,7 +1,3 @@
-
-(defun apply (f args)
-  (eval (cons f args)))
-
 (defun test-it (n c res)
   (if (= n 0) t
     (progn

--- a/tests/tests/test_type_promote_add_1.lisp
+++ b/tests/tests/test_type_promote_add_1.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of byte type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (+ 1b 1b)) type-char))
 (define a2 (eq (type-of (+ 1b 1)) type-i))
 (define a3 (eq (type-of (+ 1b 1u)) type-u))

--- a/tests/tests/test_type_promote_add_2.lisp
+++ b/tests/tests/test_type_promote_add_2.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (+ 1 1b)) type-i))
   (define a2 (eq (type-of (+ 1 1)) type-i))

--- a/tests/tests/test_type_promote_add_3.lisp
+++ b/tests/tests/test_type_promote_add_3.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (+ 1u 1b)) type-u))
   (define a2 (eq (type-of (+ 1u 1)) type-u))

--- a/tests/tests/test_type_promote_add_4.lisp
+++ b/tests/tests/test_type_promote_add_4.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (+ 1i32 1b)) type-i32))
   (define a2 (eq (type-of (+ 1i32 1)) type-i))

--- a/tests/tests/test_type_promote_add_5.lisp
+++ b/tests/tests/test_type_promote_add_5.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (+ 1u32 1b)) type-u32))
   (define a2 (eq (type-of (+ 1u32 1)) type-i))

--- a/tests/tests/test_type_promote_add_6.lisp
+++ b/tests/tests/test_type_promote_add_6.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (+ 1i64 1b)) type-i64))
   (define a2 (eq (type-of (+ 1i64 1)) type-i64))

--- a/tests/tests/test_type_promote_add_7.lisp
+++ b/tests/tests/test_type_promote_add_7.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (+ 1u64 1b)) type-u64))
 (define a2 (eq (type-of (+ 1u64 1)) type-u64))
 (define a3 (eq (type-of (+ 1u64 1u)) type-u64))

--- a/tests/tests/test_type_promote_add_8.lisp
+++ b/tests/tests/test_type_promote_add_8.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of f32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (+ 1.0f32 1b)) type-float))
 (define a2 (eq (type-of (+ 1.0f32 1)) type-float))
 (define a3 (eq (type-of (+ 1.0f32 1u)) type-float))

--- a/tests/tests/test_type_promote_add_9.lisp
+++ b/tests/tests/test_type_promote_add_9.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of f64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (+ 1.0f64 1b)) type-double))
 (define a2 (eq (type-of (+ 1.0f64 1)) type-double))
 (define a3 (eq (type-of (+ 1.0f64 1u)) type-double))

--- a/tests/tests/test_type_promote_mul_1.lisp
+++ b/tests/tests/test_type_promote_mul_1.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of byte type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (* 1b 1b)) type-char))
 (define a2 (eq (type-of (* 1b 1)) type-i))
 (define a3 (eq (type-of (* 1b 1u)) type-u))

--- a/tests/tests/test_type_promote_mul_2.lisp
+++ b/tests/tests/test_type_promote_mul_2.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (* 1 1b)) type-i))
   (define a2 (eq (type-of (* 1 1)) type-i))

--- a/tests/tests/test_type_promote_mul_3.lisp
+++ b/tests/tests/test_type_promote_mul_3.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (* 1u 1b)) type-u))
   (define a2 (eq (type-of (* 1u 1)) type-u))

--- a/tests/tests/test_type_promote_mul_4.lisp
+++ b/tests/tests/test_type_promote_mul_4.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (* 1i32 1b)) type-i32))
   (define a2 (eq (type-of (* 1i32 1)) type-i))

--- a/tests/tests/test_type_promote_mul_5.lisp
+++ b/tests/tests/test_type_promote_mul_5.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (* 1u32 1b)) type-u32))
   (define a2 (eq (type-of (* 1u32 1)) type-i))

--- a/tests/tests/test_type_promote_mul_6.lisp
+++ b/tests/tests/test_type_promote_mul_6.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of i64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (if (is-64bit) {
   (define a1 (eq (type-of (* 1i64 1b)) type-i64))
   (define a2 (eq (type-of (* 1i64 1)) type-i64))

--- a/tests/tests/test_type_promote_mul_7.lisp
+++ b/tests/tests/test_type_promote_mul_7.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of u64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (* 1u64 1b)) type-u64))
 (define a2 (eq (type-of (* 1u64 1)) type-u64))
 (define a3 (eq (type-of (* 1u64 1u)) type-u64))

--- a/tests/tests/test_type_promote_mul_8.lisp
+++ b/tests/tests/test_type_promote_mul_8.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of f32 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (* 1.0f32 1b)) type-float))
 (define a2 (eq (type-of (* 1.0f32 1)) type-float))
 (define a3 (eq (type-of (* 1.0f32 1u)) type-float))

--- a/tests/tests/test_type_promote_mul_9.lisp
+++ b/tests/tests/test_type_promote_mul_9.lisp
@@ -1,8 +1,6 @@
 
 ;; Promotion of f64 type
 
-(defun apply (f x) (eval (cons f x)))
-
 (define a1 (eq (type-of (* 1.0f64 1b)) type-double))
 (define a2 (eq (type-of (* 1.0f64 1)) type-double))
 (define a3 (eq (type-of (* 1.0f64 1u)) type-double))


### PR DESCRIPTION
Re-open of #30, which was merged but shortly thereafter erased from the history since a bug with GC was found in it. This PR fixes that.

The fixes are in the last commit, including some tests which hopefully would have caught all of the issues. I've sucessefully ran the GC tests.

I also took the decision to drop d97f2d3, which added benchmark results for the old broken version. I assumed that it wouldn't be that intreseting, but please shout at me if you would like to keep it!