### PR TITLE
Fixed some warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CCFLAGS = -Wall -Wextra -Wshadow -Wjump-misses-init -pedantic -std=c99
 
 ifndef PLATFORM
   BUILD_DIR = build/linux-x86
-  CCFLAGS += -g -O2 -m32 
+  CCFLAGS += -g -O2 -m32
   CCFLAGS += -D_PRELUDE
   PLATFORMSRC = platform/linux/src
   PLATFORMINC = platform/linux/include
@@ -20,13 +20,13 @@ ifeq ($(PLATFORM),linux-x64)
   PLATFORMSRC = platform/linux/src
   PLATFORMINC = platform/linux/include
   CC=gcc
-  AR=ar	
+  AR=ar
 endif
 
 ifeq ($(PLATFORM), zynq)
   CROSS_COMPILE = arm-none-eabi-
   BUILD_DIR = build/zynq
-  CCFLAGS += -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard -O2 
+  CCFLAGS += -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard -O2
   CCFLAGS += -D_PRELUDE
 endif
 
@@ -50,10 +50,20 @@ endif
 
 ifeq ($(PLATFORM), pi) #for compiling natively on the pi
   BUILD_DIR = build/pi
-  CCFLAGS += -g -O2 -m32 
+  CCFLAGS += -g -O2 -m32
   CCFLAGS += -D_PRELUDE
   PLATFORMSRC = platform/linux/src
   PLATFORMINC = platform/linux/include
+endif
+
+ifeq ($(PLATFORM), macos-arm64)
+  BUILD_DIR = build/macos-arm64
+  CCFLAGS += -g -O2 -m32
+  CCFLAGS += -D_PRELUDE
+  PLATFORMSRC = platform/linux/src
+  PLATFORMINC = platform/linux/include
+  CC=clang
+  AR=ar
 endif
 
 SOURCE_DIR = src
@@ -86,11 +96,11 @@ LIB = $(BUILD_DIR)/liblispbm.a
 
 all: $(OBJECTS) $(LIB)
 
-debug: CCFLAGS += -g 
+debug: CCFLAGS += -g
 debug: $(OBJECTS) $(LIB)
 
-$(LIB): $(OBJECTS) 
-	$(AR) -rcs $@ $(OBJECTS) 
+$(LIB): $(OBJECTS)
+	$(AR) -rcs $@ $(OBJECTS)
 
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c
 	$(CC) $(INCLUDE_DIR) -I$(PLATFORMINC) $(CCFLAGS) -c $< -o $@

--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -3298,7 +3298,7 @@ static void cont_closure_args_rest(eval_context_t *ctx) {
     ctx->curr_exp = exp;
   } else {
     stack_reserve(ctx,1)[0] = CLOSURE_ARGS_REST;
-    sptr[3] = get_cdr(args);  
+    sptr[3] = get_cdr(args);
     ctx->curr_exp = get_car(args);
     ctx->curr_env = arg_env;
   }
@@ -4940,7 +4940,7 @@ static void cont_move_list_to_flash(eval_context_t *ctx) {
 
   lbm_value new_lst = ENC_SYM_NIL;
   // Allocate element ptr storage after storing the element to flash.
-  handle_flash_status(request_flash_storage_cell(lbm_enc_cons_ptr(LBM_PTR_NULL), &new_lst)); 
+  handle_flash_status(request_flash_storage_cell(lbm_enc_cons_ptr(LBM_PTR_NULL), &new_lst));
 
   if (lbm_is_symbol_nil(fst)) {
     lst = new_lst;
@@ -5695,7 +5695,7 @@ lbm_cid lbm_eval_program_ext(lbm_value lisp, unsigned int stack_size) {
   return lbm_create_ctx(lisp, ENC_SYM_NIL, stack_size, NULL);
 }
 
-int lbm_eval_init() {
+int lbm_eval_init(void) {
   if (!qmutex_initialized) {
     mutex_init(&qmutex);
     qmutex_initialized = true;

--- a/src/extensions/ttf_extensions.c
+++ b/src/extensions/ttf_extensions.c
@@ -357,7 +357,7 @@ lbm_value ext_ttf_prepare_bin(lbm_value *args, lbm_uint argn) {
       if (kern_tab_bytes <=  0) {
         lbm_free(unique_utf32);
         return ENC_SYM_EERROR;
-      } 
+      }
 
       int glyph_gfx_size = glyphs_img_data_size(&sft, fmt, unique_utf32, n);
       if (glyph_gfx_size <= 0) {
@@ -686,18 +686,18 @@ lbm_value ttf_text_bin(lbm_value *args, lbm_uint argn) {
 
       uint32_t num_colors = 1 << src.fmt;
       for (int j = 0; j < src.height; j++) {
-        for (int i = 0; i < src.width; i ++) {
+        for (int k = 0; k < src.width; k ++) {
           // the bearing should not be accumulated into the advances
 
-          uint32_t p = getpixel(&src, i, j);
+          uint32_t p = getpixel(&src, k, j);
           if (p) { // only draw colored
             uint32_t c = colors[p & (num_colors-1)]; // ceiled
             if (up) {
-              putpixel(&tgt, x_pos + (j + (int)y_n), y_pos - (i + (int)(x_n + left_side_bearing)), c);
+              putpixel(&tgt, x_pos + (j + (int)y_n), y_pos - (k + (int)(x_n + left_side_bearing)), c);
             } else if (down) {
-              putpixel(&tgt, x_pos - (j + (int)y_n), y_pos + (i + (int)(x_n + left_side_bearing)), c);
+              putpixel(&tgt, x_pos - (j + (int)y_n), y_pos + (k + (int)(x_n + left_side_bearing)), c);
             } else {
-              putpixel(&tgt, x_pos + (i + (int)(x_n + left_side_bearing)), y_pos + (j + (int)y_n), c);
+              putpixel(&tgt, x_pos + (k + (int)(x_n + left_side_bearing)), y_pos + (j + (int)y_n), c);
             }
           }
         }

--- a/src/fundamental.c
+++ b/src/fundamental.c
@@ -509,7 +509,7 @@ static lbm_value fundamental_numeq(lbm_value *args, lbm_uint nargs, eval_context
         res = ENC_SYM_TERROR;
         break;
       }
-      if (!compare_num(a, b) == 0) {
+      if (!(compare_num(a, b) == 0)) {
         res = ENC_SYM_NIL;
         break;
       }


### PR DESCRIPTION
I've been trying to get LispBM to compile on my macbook. I've cleaned up a bunch of warnings and added a PLATFORM for macos-arm.

The repl is still todo. I've managed to get all the files to compile but the linking fails with the following error which I haven't been able to fix:
`ld: unknown/unsupported architecture name for: -arch armv4t`
