### PR TITLE
Make the repl run on macos

### DIFF
--- a/repl/README.md
+++ b/repl/README.md
@@ -18,19 +18,26 @@ needed.
         64Bit              | 32Bit
         ---------------------------
         libsdl2-dev        |
-        libsdl2-image-dev  | 
+        libsdl2-image-dev  |
         libpng-dev         | libpng-dev:i386
 
 **Note** that installing libsdl2-dev:i386/libsdl2-image-dev:i386 on UBUNTU 24.04 seems to brick the
 entire OS! So I cannot recommend trying that... But if anyone know what is going
-on there, please let me know! 
+on there, please let me know!
 
 To generate dot graphs from LBM, also install graphviz:
 
 ```
 sudo apt install graphviz
-``` 
+```
 
+### Dependencies on MACOS
+
+In order to build the repl on Macos, you need to install libpng using brew as below.
+
+'brew install libpng readline'
+
+You need to build the `all64` target, and set `PLATFORM=macos-arm` when building.
 
 ## Build
 

--- a/repl/repl.c
+++ b/repl/repl.c
@@ -2188,7 +2188,7 @@ int main(int argc, char **argv) {
   image_storage = mmap(IMAGE_FIXED_VIRTUAL_ADDRESS,
                        IMAGE_STORAGE_SIZE,
                        PROT_READ | PROT_WRITE,
-                       MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (((int)image_storage) == -1) {
     printf("error mapping fixed location for flash emulation\n");
     terminate_repl(REPL_EXIT_CRITICAL_ERROR);


### PR DESCRIPTION
Removing MAP_FIXED made it work.
I've verified that it works by running the test in `t1.lisp` file.

I've updated the README.md with some instructions also.