### PR TITLE
Fix regression in new blit code that broke compatibility with old code

### DIFF
--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -2419,7 +2419,7 @@ static void cont_wait(eval_context_t *ctx) {
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static inline __attribute__ ((always_inline)) lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
+static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
   /* Continuation created using call-cc.
    * ((SYM_CONT . cont-array) arg0 )
    */
@@ -2466,7 +2466,7 @@ static inline __attribute__ ((always_inline)) lbm_value setup_cont(eval_context_
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static inline __attribute__ ((always_inline)) lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
+static lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
   // continuation created using call-cc-unsafe
   // ((SYM_CONT_SP . stack_ptr) arg0 )
   lbm_value c = get_cadr(ctx->r); /* should be the stack_ptr*/

--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -2419,7 +2419,7 @@ static void cont_wait(eval_context_t *ctx) {
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
+static inline __attribute__ ((always_inline)) lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
   /* Continuation created using call-cc.
    * ((SYM_CONT . cont-array) arg0 )
    */
@@ -2466,7 +2466,7 @@ static lbm_value setup_cont(eval_context_t *ctx, lbm_value args) {
  * @return lbm_value The resulting argument value which should either be
  *   evaluated or passed on directly depending on how you use this.
  */
-static lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
+static inline __attribute__ ((always_inline)) lbm_value setup_cont_sp(eval_context_t *ctx, lbm_value args) {
   // continuation created using call-cc-unsafe
   // ((SYM_CONT_SP . stack_ptr) arg0 )
   lbm_value c = get_cadr(ctx->r); /* should be the stack_ptr*/

--- a/src/extensions/display_extensions.c
+++ b/src/extensions/display_extensions.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2023, 2024  Benjamin Vedder            benjamin@vedder.se
+  Copyright 2023 - 2025 Benjamin Vedder            benjamin@vedder.se
   Copyright 2023 - 2025 Joel Svensson              svenssonjoel@yahoo.se
   Copyright 2023        Rasmus Söderhielm          rasmus.soderhielm@gmail.com
   Copyright 2025        Joakim Lundborg            joakim.lundborg@gmail.com
@@ -2730,8 +2730,8 @@ static lbm_value ext_blit(lbm_value *args, lbm_uint argn) {
         scale,
         lbm_dec_as_i32(arg_dec.args[2]),
         arg_dec.attr_tile.is_valid,
-        arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[0]) : lbm_dec_as_i32(arg_dec.args[0]),
-        arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[1]) : lbm_dec_as_i32(arg_dec.args[1]),
+        arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[0]) : 0,
+        arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[1]) : 0,
         arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[2]) : dest_buf.width,
         arg_dec.attr_clip.is_valid ? lbm_dec_as_i32(arg_dec.attr_clip.args[3]) : dest_buf.height
     );


### PR DESCRIPTION
This change made it work on my other display with the same code from before. @cortex can you check if this change still makes it work as you intended?