### PR TITLE
fix: Make string and character escapes consistent

### DIFF
--- a/doc/lbmref.lisp
+++ b/doc/lbmref.lisp
@@ -167,12 +167,14 @@
                         "a qualifier string.  The qualifiers available in LBM are: `b`, `i`,"
                         "`u`, `i32`, `u32`, `i64`, `u64`, `f32` and `f63`.  The `i` and `f32`"
                         "qualifiers are never strictly needed but can be added if one so"
-                        "wishes."
+                        "wishes. An alternative way of writing byte literals is using"
+                        "[Character literals](#character-literals) (e.g. `\\#a`)."
                         ))
             (para (list "So for example:"
                         ))
             (bullet '("`1b`     - Specifies a byte typed value of 1"
                       "`1.0f64` - Specifies a 64bit float with value 1.0."
+                      "`\\#a`   - Specifies a byte type value of 97."
                       ))
             (para (list "**Note** that it is an absolute requirement to include a decimal when"
                         "writing a floating point literal in LBM."
@@ -218,6 +220,64 @@
             ))
   )
 
+(defun ch-strings ()
+  (section 2 "Strings"
+           (list
+            (para (list "LBM supports string literals, consisting of a pair of double quotes (`\"`)"
+                        "with a string of characters in between. These evaluate to a byte array"
+                        "containing the bytes of these characters (in the source code's encoding),"
+                        "followed by a zero byte."
+                        ))
+            (para (list "Special characters can be written using escape sequences. They take the"
+                        "form of a backslash character (`\\`) followed by some character from the"
+                        "list below and are replaced with their corresponding character at read"
+                        "time. A backslash followed by any other character is a read error."
+                        ))
+            (table '("Escape sequence" "ASCII value" "C equivalent" "Character represented")
+                   '(("`\\0`"  "0x0"  "`\\0`"  "Zero byte")
+                     ("`\\a`"  "0x7"  "`\\a`"  "[Bell character](https://en.wikipedia.org/wiki/Bell_character)")
+                     ("`\\b`"  "0x8"  "`\\b`"  "[Backspace](https://en.wikipedia.org/wiki/Backspace#^H)")
+                     ("`\\t`"  "0x9"  "`\\t`"  "[Horizontal Tab](https://en.wikipedia.org/wiki/Horizontal_Tab)")
+                     ("`\\n`"  "0xA"  "`\\n`"  "[Newline](https://en.wikipedia.org/wiki/Newline)")
+                     ("`\\v`"  "0xB"  "`\\v`"  "[Vertical tab](https://en.wikipedia.org/wiki/Vertical_Tab)")
+                     ("`\\f`"  "0xC"  "`\\f`"  "[Form feed](https://en.wikipedia.org/wiki/Formfeed)")
+                     ("`\\r`"  "0xD"  "`\\r`"  "[Carriage return](https://en.wikipedia.org/wiki/Carriage_Return)")
+                     ("`\\e`"  "0x1B" "`\\e`"  "[Escape character](https://en.wikipedia.org/wiki/Escape_character#ASCII_escape_character)")
+                     ("`\\s`"  "0x20" "-"      "Space ` `")
+                     ("`\\\"`" "0x22" "`\\\"`" "Double quote `\"`")
+                     ("`\\\\`" "0x5C" "`\\\\`" "[Backslash](https://en.wikipedia.org/wiki/Backslash) `\\`")
+                     ("`\\d`"  "0x7F" "-"      "[Delete character](https://en.wikipedia.org/wiki/Delete_character)")
+                     ))
+            (para (list "Note that unlike other languages, single quotes (`'`) can't be used to"
+                        "form string literals as it's busy being used for"
+                        "[quoting](#quotes-and-quasiquotation)! Therefore it doesn't need to be"
+                        "escaped within string literals."
+                        ))
+            end
+            (character-literals)
+           ))
+  )
+
+(defun character-literals ()
+  (section 3 "Character literals"
+           (list
+            (para (list "Individual characters can be written using character literals. They take"
+                        "the form of `\\#` followed by any ASCII character (e.g. `\\#a` or `\\#X`),"
+                        "and evaluate to their corresponding numerical byte value (note the type!)."
+                        "Like strings, character literals also support escape sequences, in which"
+                        "case they evaluate to its value from the above table, and any invalid"
+                        "characters result in a read error."
+                        ))
+            (code '((read-eval "\\#a")
+                    (read-eval "\\#A")
+                    (read-eval "\\# ")
+                    (read-eval "\\#\\n")
+                    (read-eval "\\#\\\\")
+                    (read-eval "\\#\\0")
+                    ))
+            end
+           ))
+)
 
 (defun semantics ()
   (section 3 "The meaning (semantics) that LispBM imposes on S-Expressions"
@@ -421,10 +481,10 @@
                           ))
             (para (list "In LispBM the set of atoms consist of:"
                         ))
-            (bullet (list "Numbers: Such as `1`, `2`, `3.14`, `65b`, `2u32`"
-                          "Strings: Such as \"hello world\", \"door\" ..."
+            (bullet (list "[Numbers](#numbers-and-numerical-types): Such as `1`, `2`, `3.14`, `65b`, `2u32`"
+                          "[Strings](#strings): Such as \"hello world\", \"door\" ..."
                           "Byte Arrays: Such as [1 2 3 4 5]"
-                          "Symbols: Such as `a`, `lambda`, `define`, `kurt-russel` ..."
+                          "[Symbols](#about-symbols): Such as `a`, `lambda`, `define`, `kurt-russel` ..."
                           ))
             (para (list "In LispBM a pair of S-expressions is created by an application of `cons` as `(cons a b)`"
                         "which creates the pair `(a . b)`. Convention is that `(e0 e1 ... eN)` = `(e0 . ( e1 . ... ( eN . nil)))`."
@@ -3165,6 +3225,7 @@
    (section 1 "LispBM Reference Manual"
             (list ch-symbols
                   ch-numbers
+                  (ch-strings)
                   ch-syntax-semantics
                   ch-fun-imp
                   (section 1 "Reference"

--- a/tests/tests/test_characters.lisp
+++ b/tests/tests/test_characters.lisp
@@ -1,0 +1,10 @@
+(check (and
+    (eq \#a 97b)
+    (eq "hi" [\#h \#i \#\0])
+    (eq [7 \#\b 9] [7 8 9]) ; scary D:
+    (eq (trap (read "\\#\\I")) '(exit-error read_error))
+    (eq
+        (list \#\0 \#\a \#\b \#\t \#\n \#\v \#\f \#\r \#\e \#\s \#\" \#\\ \#\d)
+        (list 0b 7b 8b 9b 10b 11b 12b 13b 27b 32b 34b 92b 127b)
+    )
+))

--- a/tests/tests/test_string_1.lisp
+++ b/tests/tests/test_string_1.lisp
@@ -1,4 +1,8 @@
 
 (check (and (= (buflen "apa") 4)
             (= (buflen "bepa") 5)
-            (= (buflen "kurt1") 6)))
+            (= (buflen "kurt1") 6)
+            ; spell-checker: disable-next-line
+            (eq "hellö\n" [104 101 108 108 195 182 10 0])
+            (eq "\0\a\b\t\n\v\f\r\e\s\"\\\d" [0 7 8 9 10 11 12 13 27 32 34 92 127 0])
+            (eq (trap (read "\"invalid escape: \\I\"")) '(exit-error read_error))))


### PR DESCRIPTION
I noticed that the set of valid escape sequences was different between string and character literals, and thought that there isn't really a reason to keep them separate. :)

Makes the parsing of escape sequences in strings and character literals consistent by adding the characters missing to both of them, and making invalid escape sequences in strings a read error. This is a breaking change, since it previously just replaced any unknown escape sequence with "//". But I don't anticipate any codebases to be using this, since it's a rather useless "feature". ;)

I also added some tests, and a section in the LBM reference which documents all of the escape sequences.

When building one of the BLDC firmware targets, the resulting binary size has increased by just 48 bytes after this commit.

The shared implementation uses the switch statement (from the string implementation) rather than the loop of equality checks (used by the character literal implementation). From my basic understanding after reading the generated Arm assembly, it seems like the switch statement indeed does become *some sort* of jump table/magic arithmetic and not just a bunch of unrolled equality checks, meaning that it should have better performance. Altough the binary size also becomes slightly larger. If I had kept the loop instead the increase in size would have been just 16 bytes.

Also, as always: If I broke any important properties of the previous implementation, please tell me!