### PR TITLE
Add `in` fundamental

### DIFF
--- a/doc/lbmref.lisp
+++ b/doc/lbmref.lisp
@@ -1866,6 +1866,34 @@
                       ))
               end)))
 
+(define lists-in
+  (ref-entry "in"
+             (list
+              (para (list "Check if value is included in list. The form of an `in` expression is"
+                          "`(in value-expr list-expr)`. Equality is checked structurally, in the"
+                          "same way as" (str-merge (code-entry-ref "eq") ",") "meaning if you're"
+                          "checking numbers the types must match (see the following examples)."
+                          ))
+              (code '((in 3 (list 1 2 3))
+                      (in 3u (list 1 2 3))
+                      (in '(b c) '((a b) (b c)))
+                      ))
+              (para (list "This function can be used as a readable and efficient way of checking"
+                          "if a value is in some constant set of values. This often results in"
+                          "significantly less code than unrolling it as a series of"
+                          (str-merge (code-entry-ref "eq") "s") "inside an" (code-entry-ref "or")
+                          "expression."
+                          ))
+              (program '(((defun is-pet? (thing)
+                            (in thing '(cat dog)))
+                          (is-pet? 'cat)
+                          )
+                         ((is-pet? 'car))
+                         ((defun is-pet-unrolled? (thing)
+                            (or (eq thing 'cat) (eq thing 'dog)))
+                          (eq (is-pet? 'cat) (is-pet-unrolled? 'cat)))
+                         ))
+              end)))
 
 (define lists-setix
   (ref-entry "setix"
@@ -2030,6 +2058,7 @@
             lists-range
             lists-append
             lists-ix
+            lists-in
             lists-setix
             lists-setcar
             lists-setcdr

--- a/doc/lbmref.md
+++ b/doc/lbmref.md
@@ -6552,6 +6552,148 @@ Index into a list using the `ix` function. The form of an `ix` expression is `(i
 ---
 
 
+### in
+
+Check if value is included in list. The form of an `in` expression is `(in value-expr list-expr)`. Equality is checked structurally, in the same way as [`eq`](#eq), meaning if you're checking numbers the types must match (see the following examples). 
+
+<table>
+<tr>
+<td> Example </td> <td> Result </td>
+</tr>
+<tr>
+<td>
+
+```clj
+(in 3 (list 1 2 3))
+```
+
+
+</td>
+<td>
+
+```clj
+t
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+```clj
+(in 3u (list 1 2 3))
+```
+
+
+</td>
+<td>
+
+```clj
+nil
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+```clj
+(in '(b c) '((a b) (b c)))
+```
+
+
+</td>
+<td>
+
+```clj
+t
+```
+
+
+</td>
+</tr>
+</table>
+
+This function can be used as a readable and efficient way of checking if a value is in some constant set of values. This often results in significantly less code than unrolling it as a series of [`eq`](#eq)s inside an [`or`](#or) expression. 
+
+<table>
+<tr>
+<td> Example </td> <td> Result </td>
+</tr>
+<tr>
+<td>
+
+
+```clj
+(defun is-pet? (thing)
+  (in thing '(cat dog)))
+(is-pet? 'cat)
+```
+
+
+</td>
+<td>
+
+
+```clj
+t
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+
+```clj
+(is-pet? 'car)
+```
+
+
+</td>
+<td>
+
+
+```clj
+nil
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+
+```clj
+(defun is-pet-unrolled? (thing)
+  (or (eq thing 'cat) (eq thing 'dog)))
+(eq (is-pet? 'cat) (is-pet-unrolled? 'cat))
+```
+
+
+</td>
+<td>
+
+
+```clj
+t
+```
+
+
+</td>
+</tr>
+</table>
+
+
+
+
+---
+
+
 ### setix
 
 Destructively update an element in a list. The form of a `setix` expression is `(setix list-expr index-expr value-expr)`. Indexing starts from 0 and if you index out of bounds the result is nil. A negative value -n will update the nth value from the end of the list. 
@@ -8928,7 +9070,7 @@ The `val-expr` can be observed if the thread exit status is captured using `spaw
 
 
 ```clj
-(exit-ok 79659 kurt-russel)
+(exit-ok 81541 kurt-russel)
 ```
 
 

--- a/include/lbm_defines.h
+++ b/include/lbm_defines.h
@@ -345,6 +345,7 @@
 #define SYM_ARRAY               0x20041
 #define SYM_IS_STRING           0x20042
 #define SYM_IS_CONSTANT         0x20043
+#define SYM_IN                  0x20044
 
 // Apply funs:
 // Get their arguments in evaluated form on the stack.

--- a/src/fundamental.c
+++ b/src/fundamental.c
@@ -1473,6 +1473,30 @@ static lbm_value fundamental_is_constant(lbm_value *args, lbm_uint argn, eval_co
   return res;
 }
 
+// signature: (in value lst)
+// Check if value is in list using structural equality.
+static lbm_value fundamental_in(lbm_value *args, lbm_uint argn, eval_context_t *ctx) {
+  (void) ctx;
+  
+  lbm_value res = ENC_SYM_TERROR;
+  if (argn == 2 && lbm_is_list(args[1])) {
+    res = ENC_SYM_NIL;
+
+    lbm_value value = args[0];
+    lbm_value current = args[1];
+    while (lbm_is_cons(current)) {
+      // Safety: Already checked that current is cons
+      lbm_cons_t *cell = lbm_ref_cell(current);
+      if (struct_eq(value, cell->car)) {
+        res = ENC_SYM_TRUE;
+        break;
+      }
+      current = cell->cdr;
+    }
+  }
+  return res;
+}
+
 const fundamental_fun fundamental_table[] =
   {fundamental_add,
    fundamental_sub,
@@ -1541,5 +1565,6 @@ const fundamental_fun fundamental_table[] =
    fundamental_identity,
    fundamental_array,
    fundamental_is_string,
-   fundamental_is_constant
+   fundamental_is_constant,
+   fundamental_in,
   };

--- a/src/symrepr.c
+++ b/src/symrepr.c
@@ -199,6 +199,7 @@ special_sym const special_symbols[] =  {
   {"setix"            , SYM_SET_IX},
   {"length"           , SYM_LIST_LENGTH},
   {"range"            , SYM_RANGE},
+  {"in"               , SYM_IN},
 
   {"assoc"          , SYM_ASSOC}, // lookup an association
   {"cossa"          , SYM_COSSA}, // lookup an association "backwards"


### PR DESCRIPTION
Adds the `in` fundamental function which checks if a given value is included in a list.
A good use case for it is to check if a value is in some constant set of values. This would traditionally be achieved as a series of `eq` expressions wrapped in an`or` expression, e.g.
`(or (eq value 'a) (eq value 'b) (eq value 'c))`. With `in` this can be written as `(in value '(a b c)')`, which is arguably much easier to parse (at least after you've become familiar with the pattern).

The reason this should be a builtin is that it's much more efficient than an equivalent user implementation. This is the best I could think of:
```clj
(defun in-user (value lst)
  (foldl
    (fn (result lst-value)
      (or result (eq lst-value value)))
    false
    lst))
```

Then comparing `(in-user 3 '(1 2 3)')` to `(in 3 '(1 2 3)')` the builtin one was 5x faster! A nice bonus is that it's also slightly more efficient than manually unrolling the equality checks inside an `or` expression (it was just 1.3x faster though). This was measured by running each expression 10000 times, taking the average. The tests were ran in the 32-bit repl on my x86 machine. As it's not an embedded system the results should of course be taken with a grain of salt.

If you want to try it yourself, this is the complete code I used:
```clj
(defmacro benchmark (name iterations expr)
    `(benchmark-inner ,name ,iterations ',expr)
)

(defun benchmark-inner (name iterations code) {
    (print (str-merge "Benchmark \"" name "\""))
    (print (str-merge "Running " (str-from-n iterations) " iterations of " (to-str code)))
    (var start (systime))
    
    (looprange i 0 iterations (eval code))
    
    (var duration-secs (/ (secs-since start) iterations))
    (var duration-str (str-merge (str-from-n (* duration-secs 1000.0) "%.4f") " ms"))
    
    (print (str-merge "Average duration:"))
    (print (str-merge "  " duration-str))
    (print "")
})

(defun in-lbm (value lst)
  (foldl
    (fn (result lst-value)
      (or result (eq lst-value value)))
    false
    lst))

(gc)
(benchmark "inline" 10000 (or (eq 3 1) (eq 3 2) (eq 3 3)))
(gc)
(benchmark "user" 10000 (in-lbm 3 '(1 2 3)))
(gc)
(benchmark "builtin" 10000 (in 3 '(1 2 3)))
```