### PR TITLE
Restore `setassoc` behavior for missing keys

### DIFF
--- a/doc/lbmref.lisp
+++ b/doc/lbmref.lisp
@@ -2084,10 +2084,14 @@
              (list
               (para (list "The `setassoc` function destructively updates a key-value mapping in an"
                           "alist. The form of a `setassoc` expression is `(setassoc alist-expr key-expr value-expr)`."
+                          "If you assign a key which doesn't exist in the original alist, it is"
+                          "left unchanged, while another association pair is added to the returned list."
                           ))
               (program '(((define apa (list '(1 . horse) '(2 . donkey) '(3 . shark)))
                           (setassoc apa 2 'llama)
                           )
+                         ((setassoc apa 4 'mouse))
+                         (apa)
                          ))
               end)))
 

--- a/doc/lbmref.md
+++ b/doc/lbmref.md
@@ -7132,7 +7132,7 @@ The `cossa` function looks up the first key in an alist that matches a given val
 
 ### setassoc
 
-The `setassoc` function destructively updates a key-value mapping in an alist. The form of a `setassoc` expression is `(setassoc alist-expr key-expr value-expr)`. 
+The `setassoc` function destructively updates a key-value mapping in an alist. The form of a `setassoc` expression is `(setassoc alist-expr key-expr value-expr)`. If you assign a key which doesn't exist in the original alist, it is left unchanged, while another association pair is added to the returned list. 
 
 <table>
 <tr>
@@ -7145,6 +7145,46 @@ The `setassoc` function destructively updates a key-value mapping in an alist. T
 ```clj
 (define apa (list '(1 . horse) '(2 . donkey) '(3 . shark)))
 (setassoc apa 2 'llama)
+```
+
+
+</td>
+<td>
+
+
+```clj
+((1 . horse) (2 . llama) (3 . shark))
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+
+```clj
+(setassoc apa 4 'mouse)
+```
+
+
+</td>
+<td>
+
+
+```clj
+((4 . mouse) (1 . horse) (2 . llama) (3 . shark))
+```
+
+
+</td>
+</tr>
+<tr>
+<td>
+
+
+```clj
+apa
 ```
 
 
@@ -8928,7 +8968,7 @@ The `val-expr` can be observed if the thread exit status is captured using `spaw
 
 
 ```clj
-(exit-ok 79659 kurt-russel)
+(exit-ok 79974 kurt-russel)
 ```
 
 

--- a/src/fundamental.c
+++ b/src/fundamental.c
@@ -930,13 +930,13 @@ static lbm_value fundamental_acons(lbm_value *args, lbm_uint nargs, eval_context
   return result;
 }
 
-static bool set_assoc(lbm_value *res, lbm_value keyval, lbm_value assocs) {
-  lbm_value curr = assocs;
+static bool set_assoc(lbm_value *res, lbm_value keyval, lbm_value assoc_list) {
+  lbm_value curr = assoc_list;
   lbm_value key = lbm_car(keyval);
   while (lbm_is_cons(curr)) {
     if (struct_eq(key, lbm_caar(curr))) {
       lbm_set_car(curr, keyval);
-      *res = assocs;
+      *res = assoc_list;
       return true;
     }
     curr = lbm_cdr(curr);

--- a/src/fundamental.c
+++ b/src/fundamental.c
@@ -930,34 +930,32 @@ static lbm_value fundamental_acons(lbm_value *args, lbm_uint nargs, eval_context
   return result;
 }
 
-static bool set_assoc(lbm_value *res, lbm_value keyval, lbm_value assoc_list) {
+static lbm_value set_assoc(lbm_value assoc_list, lbm_value keyval) {
   lbm_value curr = assoc_list;
   lbm_value key = lbm_car(keyval);
   while (lbm_is_cons(curr)) {
     if (struct_eq(key, lbm_caar(curr))) {
       lbm_set_car(curr, keyval);
-      *res = assoc_list;
-      return true;
+      return assoc_list;
     }
     curr = lbm_cdr(curr);
   }
-  return false;
+  // Assoc-list does not contain key.
+  // Note: Memory errors are implicitly handled by the caller.
+  return lbm_cons(keyval, assoc_list);
 }
 
 static lbm_value fundamental_set_assoc(lbm_value *args, lbm_uint nargs, eval_context_t *ctx) {
   (void)ctx;
-  lbm_value result = ENC_SYM_TERROR;
   lbm_value keyval;
   if (nargs == 3) {
     keyval = lbm_cons(args[1], args[2]);
+    // Check if ENC_SYM_MERROR.
     if (lbm_is_symbol(keyval)) return keyval;
   } else if (nargs == 2 && lbm_is_cons(args[1])) {
     keyval = args[1];
-  } else return result;
-  if (!set_assoc(&result, keyval, args[0])) {
-    result = ENC_SYM_EERROR;
-  }
-  return result;
+  } else return ENC_SYM_TERROR;
+  return set_assoc(args[0], keyval);
 }
 
 static lbm_value fundamental_cossa(lbm_value *args, lbm_uint nargs, eval_context_t *ctx) {


### PR DESCRIPTION
Previously, if `setassoc` was called with a key which wasn't set it would return a list with an added new pair. This behavior was removed in 3c375f7, with it now instead raising an eval_error. This PR reimplements the old behavior when it comes to missing keys.

While the behavior was never explicitly mentioned in the documentation it is still a useful feature, that is hard to emulate in an efficient manner, since a userland implementation would have to check if the keys exist before inserting them, which isn't implemented in any built-in
function.

We also have code at Lind which depend on this behavior, so if anything it would be helpful to not break backward compatability.

I then also updated the documentation to specify this behavior.