### PR TITLE
repl: Improve REPL prompt printing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
         "glyps",
         "hline",
         "lbmref",
+        "lispif",
         "lmtx",
         "mkarray",
         "noreturn",
@@ -51,6 +52,7 @@
         "rptr",
         "sierp",
         "snoc",
+        "symrepr",
         "tableize",
         "TOKCOMMAAT",
         "TOKTYPEF",
@@ -59,6 +61,9 @@
         "Tpng",
         "ttfref",
         "unflattening",
+        "vescif",
+        "vesctcp",
+        "WSADATA",
         "yeet"
     ]
 }

--- a/include/eval_cps.h
+++ b/include/eval_cps.h
@@ -113,6 +113,8 @@ extern const fundamental_fun fundamental_table[];
  */
 typedef void (*ctx_fun)(eval_context_t *, void*, void*);
 
+extern int (*lbm_printf_callback)(const char *, ...);
+
 /* Common interface */
 /** Get the global environment
  *

--- a/repl/repl_exts.c
+++ b/repl/repl_exts.c
@@ -38,6 +38,7 @@
 #include "extensions/ttf_extensions.h"
 #include "extensions/random_extensions.h"
 
+#include "eval_cps.h"
 #include "lbm_image.h"
 #include "lbm_flat_value.h"
 
@@ -198,13 +199,13 @@ lbm_value ext_print(lbm_value *args, lbm_uint argn) {
     if (lbm_is_ptr(t) && lbm_type_of(t) == LBM_TYPE_ARRAY) {
       lbm_array_header_t *array = (lbm_array_header_t *)lbm_car(t);
       char *data = (char*)array->data;
-      printf("%s", data);
+      lbm_printf_callback("%s", data);
     } else {
       lbm_print_value(output, 1024, t);
-      printf("%s", output);
+      lbm_printf_callback("%s", output);
     }
   }
-  printf("\n");
+  lbm_printf_callback("\n");
   return lbm_enc_sym(SYM_TRUE);
 }
 
@@ -377,13 +378,13 @@ static lbm_value ext_fwrite_value(lbm_value *args, lbm_uint argn) {
           fflush(h->fp);
           res = ENC_SYM_TRUE;
         } else {
-          printf("ALERT: Unable to flatten result value\n");
+          lbm_printf_callback("ALERT: Unable to flatten result value\n");
         }
       } else {
-        printf("ALERT: Out of memory to allocate result buffer\n");
+        lbm_printf_callback("ALERT: Out of memory to allocate result buffer\n");
       }
     } else {
-      printf("ALERT: Incorrect FV size: %d \n", fv_size);
+      lbm_printf_callback("ALERT: Incorrect FV size: %d \n", fv_size);
     }
   }
   return res;
@@ -777,14 +778,14 @@ lbm_value ext_image_save_const_heap_ix(lbm_value *args, lbm_uint argn) {
 
 int dummy_f(lbm_value v, bool shared, void *arg) {
   if (shared) {
-    printf("shared node detected\n");
+    lbm_printf_callback("shared node detected\n");
   }
   if (lbm_is_cons(v)) {
-    printf("cons\n");
+    lbm_printf_callback("cons\n");
   } else {
     char buf[256];
     lbm_print_value(buf,256, v);
-    printf("atom: %s\n", buf);
+    lbm_printf_callback("atom: %s\n", buf);
   }
   return TRAV_FUN_SUBTREE_CONTINUE;
 }


### PR DESCRIPTION
Improves the REPL prompt printing in two ways:
- The result of finished contexts is only printed if it was directly created by the REPL, i.e. if it was started by the user pressing enter.
- The prompt is cleared before any kind of output is printed and redrawn afterwards.

This means that the prompt shouldn't be able to dissapear, split up or generally be broken by other contexts printing stuff randomly or anything similar. There will always be a prompt at the end of the output buffer.

Here is an example where I've ran some commands in the REPL before and after this PR.

Before:

https://github.com/user-attachments/assets/09abdd22-d951-43fa-91b5-55b70a92bc05

After:

https://github.com/user-attachments/assets/2eb29b29-3ff3-4804-84a0-8eec75960d0c

There are some more details in the commit messages.