### PR TITLE
Macos Fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ repl/repl
 tests/test_lisp_code_cps
 /.direnv
 .aider*
+repl/.build_features
+

--- a/lispbm.mk
+++ b/lispbm.mk
@@ -24,7 +24,7 @@ LISPBM_SRC = $(LISPBM)/src/env.c \
              $(LISPBM)/src/extensions/math_extensions.c \
              $(LISPBM)/src/extensions/runtime_extensions.c \
              $(LISPBM)/src/extensions/random_extensions.c \
-	     $(LISPBM)/src/extensions/set_extensions.c \
+             $(LISPBM)/src/extensions/set_extensions.c \
              $(LISPBM)/src/extensions/display_extensions.c \
              $(LISPBM)/src/extensions/tjpgd.c \
              $(LISPBM)/src/extensions/mutex_extensions.c \
@@ -32,7 +32,7 @@ LISPBM_SRC = $(LISPBM)/src/env.c \
              $(LISPBM)/src/extensions/ttf_extensions.c \
              $(LISPBM)/src/extensions/ttf_backend.c \
              $(LISPBM)/src/extensions/schrift.c \
-	     $(LISPBM)/src/extensions/dsp_extensions.c \
+             $(LISPBM)/src/extensions/dsp_extensions.c \
              $(LISPBM)/src/extensions/crypto_extensions.c \
              $(LISPBM)/src/extensions/ecc_extensions.c
 

--- a/platform/linux/src/platform_thread.c
+++ b/platform/linux/src/platform_thread.c
@@ -24,6 +24,11 @@
 #include <errno.h>
 #include <string.h>
 
+#ifdef __APPLE__
+typedef time_t __time_t;
+typedef long __syscall_slong_t;
+#endif
+
 typedef struct {
   lbm_thread_func_t user_func;
   void *user_arg;

--- a/platform/linux/src/platform_thread.c
+++ b/platform/linux/src/platform_thread.c
@@ -83,7 +83,9 @@ bool lbm_thread_create(lbm_thread_t *t,
   }
   // np apparently means "non-portable"
   // also requires the __GNU_SOURCE define.
+#ifndef __APPLE__
   if (name) pthread_setname_np(thread->handle, name);
+#endif
 
   return true;
 }

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -23,8 +23,13 @@ LBMFLAGS = -DFULL_RTS_LIB \
 
 LDFLAGS = -lpng
 
-ifeq ($(PLATFORM), macos-arm64)
-	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include\
+# Detect OS and Architecture
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+
+# Detect macOS ARM
+ifeq ($(UNAME_S)-$(UNAME_M),Darwin-arm64)
+	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include \
 	                   -I/opt/homebrew/include/ \
 	                   -I/opt/homebrew/opt/readline/include
 	LDFLAGS += -L/opt/homebrew/opt/readline/lib -lreadline -L/opt/homebrew/lib

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -8,6 +8,8 @@ FEATURE_FILE = .build_features
 
 include $(LISPBM)/lispbm.mk
 
+CCFLAGS = ""
+
 LBMFLAGS = -DFULL_RTS_LIB \
            -DLBM_USE_DYN_MACROS \
            -DLBM_USE_DYN_LOOPS \
@@ -24,13 +26,14 @@ LDFLAGS = -lpng
 ifeq ($(PLATFORM), macos-arm64)
 	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include\
 	                   -I/opt/homebrew/include/ \
-                           -I/opt/homebrew/opt/readline/include
-	LDFLAGS += -L/opt/homebrew/opt/readline/lib -L/opt/homebrew/lib
-# To make mmap work on macOS
+	                   -I/opt/homebrew/opt/readline/include
+	LDFLAGS += -L/opt/homebrew/opt/readline/lib -lreadline -L/opt/homebrew/lib
+	# To make mmap work on macOS
 	LBMFLAGS += -D_DARWIN_C_SOURCE
 else
 	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include
 	LDFLAGS += -lpthread -lreadline -lhistory
+	CCFLAGS += -fno-pie -no-pie
 endif
 
 PLATFORM_SRC = $(LISPBM)/platform/linux/src/platform_mutex.c \
@@ -57,9 +60,9 @@ REPL_SRC  = $(LISPBM_SRC)\
 
 # Coverage build or regular
 ifneq (,$(filter coverage,$(FEATURES)))
-	CCFLAGS = -g -coverage -O0 -Wall -Wconversion -Wsign-compare -pedantic -std=c11 $(LBMFLAGS) -fno-pie -no-pie
+	CCFLAGS += -g -coverage -O0 -Wall -Wconversion -Wsign-compare -pedantic -std=c11 $(LBMFLAGS)
 else
-	CCFLAGS = -O2 -Wall -Wextra -Wshadow  -Wconversion -Wsign-compare -pedantic -std=c11 $(LBMFLAGS) -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -fno-pie -no-pie
+	CCFLAGS += -O2 -Wall -Wextra -Wshadow  -Wconversion -Wsign-compare -pedantic -std=c11 $(LBMFLAGS) -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 endif
 
 # Use 64bit

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -30,6 +30,8 @@ ifeq ($(PLATFORM), macos-arm64)
 	LDFLAGS += -L/opt/homebrew/opt/readline/lib -lreadline -L/opt/homebrew/lib
 	# To make mmap work on macOS
 	LBMFLAGS += -D_DARWIN_C_SOURCE
+	# force 64bit mode on osx
+	FEATURES += 64
 else
 	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include
 	LDFLAGS += -lpthread -lreadline -lhistory

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -45,15 +45,15 @@ PLATFORM_SRC = $(LISPBM)/platform/linux/src/platform_mutex.c \
 ## If using any of the utilities.
 LISPBM_INC += -I../utils
 
-REPL_SRC  = $(LISPBM_SRC)\
-            repl.c \
-            repl_exts.c \
-            ../utils/crc.c \
-            ../utils/packet.c \
-            vesc_express_extension_stubs.c \
-            lbm_gnuplot.c \
-            lbm_octave.c \
-            bldc_extension_stubs.c
+REPL_SRC = $(LISPBM_SRC)\
+           repl.c \
+           repl_exts.c \
+           ../utils/crc.c \
+           ../utils/packet.c \
+           vesc_express_extension_stubs.c \
+           lbm_gnuplot.c \
+           lbm_octave.c \
+           bldc_extension_stubs.c
 
 ## Dropped usage of pkg-config as it felt like more trouble than benefit.
 ## pkg-config searches for .pc files unrelated to compile flags such as -m32.

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -19,7 +19,7 @@ LBMFLAGS = -DFULL_RTS_LIB \
            -DLBM_USE_MACRO_REST_ARGS \
            -DLBM_USE_SHEBANG_COMMENTS
 
-LDFLAGS = -lpng -lm
+LDFLAGS = -lpng
 
 ifeq ($(PLATFORM), macos-arm64)
 	PLATFORM_INCLUDE = -I$(LISPBM)/platform/linux/include\

--- a/repl/Makefile
+++ b/repl/Makefile
@@ -9,7 +9,7 @@ FEATURE_FILE = .build_features
 include $(LISPBM)/lispbm.mk
 
 LBMFLAGS = -DFULL_RTS_LIB \
-	   -DLBM_USE_DYN_MACROS \
+           -DLBM_USE_DYN_MACROS \
            -DLBM_USE_DYN_LOOPS \
            -DLBM_USE_DYN_FUNS \
            -DLBM_USE_DYN_ARRAYS \
@@ -33,22 +33,22 @@ else
 	LDFLAGS += -lpthread -lreadline -lhistory
 endif
 
-PLATFORM_SRC     = $(LISPBM)/platform/linux/src/platform_mutex.c \
-                   $(LISPBM)/platform/linux/src/platform_timestamp.c \
-	           $(LISPBM)/platform/linux/src/platform_thread.c
+PLATFORM_SRC = $(LISPBM)/platform/linux/src/platform_mutex.c \
+               $(LISPBM)/platform/linux/src/platform_timestamp.c \
+               $(LISPBM)/platform/linux/src/platform_thread.c
 
 ## If using any of the utilities.
 LISPBM_INC += -I../utils
 
-REPL_SRC= $(LISPBM_SRC)\
-	  repl.c \
-	  repl_exts.c \
-          ../utils/crc.c \
-          ../utils/packet.c \
-          vesc_express_extension_stubs.c \
-	  lbm_gnuplot.c \
-          lbm_octave.c \
-          bldc_extension_stubs.c
+REPL_SRC  = $(LISPBM_SRC)\
+            repl.c \
+            repl_exts.c \
+            ../utils/crc.c \
+            ../utils/packet.c \
+            vesc_express_extension_stubs.c \
+            lbm_gnuplot.c \
+            lbm_octave.c \
+            bldc_extension_stubs.c
 
 ## Dropped usage of pkg-config as it felt like more trouble than benefit.
 ## pkg-config searches for .pc files unrelated to compile flags such as -m32.
@@ -148,8 +148,5 @@ clean:
 clean_coverage:
 	rm -f coverage/*
 
-
 $(FEATURE_FILE): FORCE
 	@echo "$(FEATURES)" | cmp -s - $@ || echo "$(FEATURES)" > $@
-
-

--- a/repl/README.md
+++ b/repl/README.md
@@ -43,37 +43,42 @@ And finally for offline rendering of fonts using freetype:
         ---------------------------
         libfreetype-dev    | libfreetype-dev:i386
 
-
-
-### Dependencies on MACOS
-
-In order to build the repl on Macos, you need to install libpng using brew as below.
-
-'brew install libpng readline'
-
-You need to build the `all64` target, and set `PLATFORM=macos-arm` when building.
-
 ## Build
 
-The REPL can be built with different feature-sets. features are selected as:
+The REPL can be built with different feature-sets. For example:
+
 ```
 make FEATURES="alsa sdl"
 ```
-which is an example of adding features for sound and graphics.
+
+will add the sound and graphics features.
 
 The total list of features is:
 
-* alsa     - Sound on Linux.
-* sdl      - Graphics on Linux.
-* freetype - Use libfreetype for font prepropressing.
-* 64       - 64Bit build.
-* coverage - Build with coverage collection.
+| -- | -- |
+| `alsa`     | Sound on Linux |
+| `sdl`      | Graphics on Linux |
+| `freetype` | Use libfreetype for font prepropressing |
+| `64`       | 64Bit build |
+| `coverage` | Build with coverage collection |
 
 To build the default target (32 bit LispBM repl) just issue the command:
 
 ```
 make
 ```
+
+### Building on MacOS
+
+_**NOTE:** The MacOS build is unsupported -- you may need to rollback to a known-working git revision to compile._
+
+In order to build the repl on MacOS, you need to install the `png` and `readline` libraries using brew as below:
+
+```
+brew install libpng readline
+```
+
+The MacOS version automatically builds the 64 bit version; 32 bit is currently unbuildable.
 
 ## install as lbm
 
@@ -84,7 +89,3 @@ make install
 ```
 
 to install the repl as `lbm` under ~/.local/bin
-
-
-
-

--- a/repl/README.md
+++ b/repl/README.md
@@ -10,10 +10,12 @@
         libhistory  | libhistory:i386
 
 Ubuntu example for obtaining 32bit dependencies
-'sudo apt-get install gcc-multilib libreadline-dev lib32readline-dev'
 
-Additionally for SDL and png support the following libraries are
-needed.
+```
+sudo apt-get install gcc-multilib libreadline-dev lib32readline-dev
+```
+
+Additionally for SDL and png support the following libraries are needed.
 
         64Bit              | 32Bit
         ---------------------------
@@ -21,9 +23,9 @@ needed.
         libsdl2-image-dev  |
         libpng-dev         | libpng-dev:i386
 
-**Note** that installing libsdl2-dev:i386/libsdl2-image-dev:i386 on UBUNTU 24.04 seems to brick the
-entire OS! So I cannot recommend trying that... But if anyone know what is going
-on there, please let me know!
+**Note** that installing libsdl2-dev:i386/libsdl2-image-dev:i386 on UBUNTU 24.04 
+seems to brick the entire OS! So I cannot recommend trying that... But if anyone 
+know what is going on there, please let me know!
 
 To generate dot graphs from LBM, also install graphviz:
 
@@ -55,12 +57,13 @@ will add the sound and graphics features.
 
 The total list of features is:
 
-| -- | -- |
-| `alsa`     | Sound on Linux |
-| `sdl`      | Graphics on Linux |
-| `freetype` | Use libfreetype for font prepropressing |
-| `64`       | 64Bit build |
-| `coverage` | Build with coverage collection |
+| Feature Flag | Feature Set Enabled                     |
+|--------------|-----------------------------------------|
+| `alsa`       | Sound on Linux                          |
+| `sdl`        | Graphics on Linux                       |
+| `freetype`   | Use libfreetype for font prepropressing |
+| `64`         | 64Bit build                             |
+| `coverage`   | Build with coverage collection          |
 
 To build the default target (32 bit LispBM repl) just issue the command:
 

--- a/repl/README.md
+++ b/repl/README.md
@@ -81,7 +81,7 @@ In order to build the repl on MacOS, you need to install the `png` and `readline
 brew install libpng readline
 ```
 
-The MacOS version automatically builds the 64 bit version; 32 bit is currently unbuildable.
+To build, call `make` as normal. The MacOS version automatically builds the 64 bit version; 32 bit is currently unbuildable.
 
 ## install as lbm
 

--- a/repl/repl.c
+++ b/repl/repl.c
@@ -1134,7 +1134,7 @@ void startup_procedure(int argc, char **argv) {
     if (!fp) {
       terminate_repl(REPL_EXIT_UNABLE_TO_OPEN_ENV_FILE);
     }
-    uint32_t num_symbols = 0;
+    //uint32_t num_symbols = 0;
     while (true) {
       uint32_t name_len;
       size_t n = fread(&name_len, 1, sizeof(uint32_t), fp);
@@ -1175,7 +1175,7 @@ void startup_procedure(int argc, char **argv) {
         //printf("pos2: %u symbols added\n", num_symbols);
       }
 
-      num_symbols ++;
+      //num_symbols ++;
       lbm_value key = lbm_enc_sym(sym_id);
       uint32_t val_len;
       n = fread(&val_len, 1, sizeof(uint32_t), fp);


### PR DESCRIPTION
This allows for the compliation of the repl on current macs.

```
git checkout https://github.com/svenssonjoel/lispBM.git
cd lispBM/repl
make
```

The 64bit flag is now forced for OSX _(if someone can get it workin in 32bit mode, that could be removed, but...)_

It also still has a SLEW of warnings being issued; they don't stop the build, but it's not clean like when this is run under ubuntu with 32bit build.  It's a lot of noise around type conversions (which, I guess kinda makes sense if types "expand" so-to-speak in the 64 vs 32 version? kinda guessing...) To be fair, I see a lot of these in the 64 build under ubuntu as well, so I suspect its the same kind of noise.

I also fixed a number of sneaky whitespace issues that popped up while I was editing away, and cleaned up the repl readme a bit.