### PR TITLE
apply_kill: Don't double free from queue mutex

### DIFF
--- a/src/eval_cps.c
+++ b/src/eval_cps.c
@@ -3177,13 +3177,11 @@ static void apply_kill(lbm_value *args, lbm_uint nargs, eval_context_t *ctx) {
     }
     lbm_mutex_lock(&qmutex);
     eval_context_t *found = NULL;
-    found = lookup_ctx_nm(&blocked, cid);
-    if (found)
+    if ((found = lookup_ctx_nm(&blocked, cid))) {
       unlink_ctx_nm(&blocked, found);
-    else
-      found = lookup_ctx_nm(&queue, cid);
-    if (found)
+    } else if ((found = lookup_ctx_nm(&queue, cid))) {
       unlink_ctx_nm(&queue, found);
+    }
 
     if (found) {
       found->K.data[found->K.sp - 1] = KILL;

--- a/tests/tests/test_kill_queue.lisp
+++ b/tests/tests/test_kill_queue.lisp
@@ -1,0 +1,12 @@
+; Checks that kill doesn't also kill threads in the running queue.
+; This would be caused by a bug which has now been fixed.
+
+; This will always be in the running queue when the main context is executing.
+(def no-sleep-ctx (spawn "no-sleep" 50 (fn () (loopwhile t nil))))
+; This will always be in the blocked queue.
+(def always-sleep-ctx (spawn "always-sleep" 50 (fn () (sleep 100))))
+
+(kill always-sleep-ctx nil)
+
+; Check that no-sleep hasn't been killed. `send` will return `nil` if it's dead.
+(check (send no-sleep-ctx nil))


### PR DESCRIPTION
Fixes a logic bug in `apply_kill` in "eval_cps.c", where it would both unlink a context from the `blocked` and `queue` queues if the context to be killed was found in `blocked`. This causes `queue` to be completely emptied, effectively killing all contexts within it.

Adds a test which fails when the bug is present (which of course passes now).

Also refactors the code so that both branches can look symmetric. :)